### PR TITLE
Use devel CUDA flavor

### DIFF
--- a/runway.yml
+++ b/runway.yml
@@ -1,5 +1,6 @@
 python: 3.6
 cuda: 9.0
+cuda_flavor: devel
 entrypoint: python server.py
 framework: tensorflow
 files:


### PR DESCRIPTION
This should fix this build error, now that we are defaulting to using the `runtime` images of CUDA.

```
  Running build step: cd lib && make && cd ..

  python setup.py build_ext --inplace
  Traceback (most recent call last):
    File "setup.py", line 63, in <module>
      CUDA = locate_cuda()
    File "setup.py", line 51, in locate_cuda
      raise EnvironmentError('The nvcc binary could not be '
  OSError: The nvcc binary could not be located in your $PATH. Either add it to your path, or set $CUDAHOME
  Makefile:2: recipe for target 'all' failed
  make: *** [all] Error 1
  Command failed: "cd lib && make && cd .."

  ERROR: Build failed
  Removing intermediate container 6e43639ae40c
  Build failed
```